### PR TITLE
Fix adding messageID header for producer

### DIFF
--- a/src/Memphis.Client/Producer/MemphisProducer.cs
+++ b/src/Memphis.Client/Producer/MemphisProducer.cs
@@ -56,7 +56,7 @@ namespace Memphis.Client.Producer
                 }
             };
 
-            if (string.IsNullOrEmpty(messageId))
+            if (!string.IsNullOrWhiteSpace(messageId))
             {
                 msg.Header.Add(MemphisHeaders.MESSAGE_ID, messageId);
             }


### PR DESCRIPTION
Fix adding messageId header.
Use IsNullOrWhiteSpace to cover white-space characters.