### PR TITLE
Support user password based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ using Memphis.Client;
 
 ### Connecting to Memphis
 
-First, we need to create or use default `ClientOptions` and then connect with Memphis by using `MemphisClientFactory.CreateClient(ClientOptions opst)`.
+First, we need to create or use default `ClientOptions` and then connect to Memphis by using `MemphisClientFactory.CreateClient(ClientOptions opst)`.
 
 ```c#
 try
@@ -73,7 +73,26 @@ try
     var options = MemphisClientFactory.GetDefaultOptions();
     options.Host = "<broker-address>";
     options.Username = "<application-type-username>";
-    options.ConnectionToken = "<token>"; // you will get it on application type user creation
+    options.ConnectionToken = "<broker-token>"; // you will get it on broker creation
+    var memphisClient = MemphisClientFactory.CreateClient(options);
+    ...
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine("Exception: " + ex.Message);
+    Console.Error.WriteLine(ex);
+}
+```
+
+We can also connect using a password:
+
+```c#
+try
+{
+    var options = MemphisClientFactory.GetDefaultOptions();
+    options.Host = "<broker-address>";
+    options.Username = "<application-type-username>";
+    options.Password = "<application-type-password>"; // you will get it on application type user creation
     var memphisClient = MemphisClientFactory.CreateClient(options);
     ...
 }
@@ -102,7 +121,7 @@ try
     var options = MemphisClientFactory.GetDefaultOptions();
     options.Host = "<memphis-host>";
     options.Username = "<application type username>";
-    options.ConnectionToken = "<broker-token>";
+    options.Password = "<application-type-password>";
     var client = MemphisClientFactory.CreateClient(options);
     
     // Second: creaing Memphis station
@@ -207,7 +226,7 @@ try
     var options = MemphisClientFactory.GetDefaultOptions();
     options.Host = "<memphis-host>";
     options.Username = "<application type username>";
-    options.ConnectionToken = "<broker-token>";
+    options.Password = "<application-type-password>";
     var client = MemphisClientFactory.CreateClient(options);
 
     // Second: creating the Memphis producer 
@@ -247,7 +266,7 @@ try
     var options = MemphisClientFactory.GetDefaultOptions();
     options.Host = "<memphis-host>";
     options.Username = "<application type username>";
-    options.ConnectionToken = "<broker-token>";
+    options.Password = "<application-type-password>";
     var client = MemphisClientFactory.CreateClient(options);
     
     // Second: creaing Memphis consumer

--- a/src/Memphis.Client/MemphisClientFactory.cs
+++ b/src/Memphis.Client/MemphisClientFactory.cs
@@ -34,9 +34,11 @@ namespace Memphis.Client
             brokerConnOptions.Servers = new[] { $"{NormalizeHost(opts.Host)}:{opts.Port}" };
             brokerConnOptions.AllowReconnect = opts.Reconnect;
             brokerConnOptions.ReconnectWait = opts.MaxReconnectIntervalMs;
+            brokerConnOptions.Timeout = opts.TimeoutMs;
             brokerConnOptions.Token = opts.ConnectionToken;
             brokerConnOptions.Name = $"{connectionId}::{opts.Username}";
             brokerConnOptions.User = opts.Username;
+            brokerConnOptions.Password = opts.Password;
             brokerConnOptions.Verbose = true;
 
             if (opts.Tls != null)

--- a/src/Memphis.Client/Options.cs
+++ b/src/Memphis.Client/Options.cs
@@ -24,6 +24,7 @@ namespace Memphis.Client
     {
         public string Host { get; set; }
         public string Username { get; set; }
+        public string Password { get; set; }
         public string ConnectionToken { get; set; }
         public int Port { get; set; }
         public bool Reconnect { get; set; }


### PR DESCRIPTION
### Motivation and Context

At the moment the SDK only allow authentication using a connection token, this will allow to authenticate using username and password.

### Type of change (Delete irrelevant items)

- [x] New feature **(non-breaking change which adds/improves functionality)**
- [x] A documentation update

### Fixes # (if relevant)

Resolves https://github.com/memphisdev/memphis.net/issues/31

### How Has This Been Tested?

Was able to connect to a Memphis instance, create a station, produce messages and consume them.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
