### PR TITLE
ProtoBuf eval update

### DIFF
--- a/src/Memphis.Client.UnitTests/AvroValidatorTest.cs
+++ b/src/Memphis.Client.UnitTests/AvroValidatorTest.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Concurrent;
+using System.Text;
+using GraphQL.Types;
+using Memphis.Client.Exception;
+using Memphis.Client.UnitTests.Validators.TestData;
+using Memphis.Client.Validators;
+using Xunit;
+
+namespace Memphis.Client.UnitTests.Validators;
+
+public class AvroValidatorTest
+{
+
+
+    private readonly ISchemaValidator _validator;
+
+    public AvroValidatorTest()
+    {
+        _validator = new AvroValidator();
+    }
+
+    #region AvroValidatorTest.ParseAndStore
+    [Theory]
+    [MemberData(nameof(AvroValidatorTestData.ValidSchema), MemberType = typeof(AvroValidatorTestData))]
+    public void ShouldReturnTrue_WhenParseAndStore_WhereValidSchemaPassed(string validSchema)
+    {
+        var actual = _validator.ParseAndStore("vaid-schema-001", validSchema);
+
+        Assert.True(actual);
+    }
+
+
+    [Theory]
+    [MemberData(nameof(AvroValidatorTestData.InvalidSchema), MemberType = typeof(AvroValidatorTestData))]
+    public void ShouldReturnFalse_WhenParseAndStore_WhereInvalidSchemaPassed(string invalidSchema)
+    {
+        var actual = _validator.ParseAndStore("invalid-schema-001", invalidSchema);
+
+        Assert.False(actual);
+    }
+
+    #endregion
+
+
+    #region AvroValidatorTest.ValidateAsync
+
+    [Theory]
+    [MemberData(nameof(AvroValidatorTestData.ValidSchemaDetail), MemberType = typeof(AvroValidatorTestData))]
+    public async Task ShouldDoSuccess_WhenValidateAsync_WhereValidDataPassed(string schemaKey, string schema, byte[] msg)
+    {
+        _validator.ParseAndStore(schemaKey, schema);
+
+        var exception = await Record.ExceptionAsync(async () => await _validator.ValidateAsync(msg, schemaKey));
+        
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [MemberData(nameof(AvroValidatorTestData.InvalidSchemaDetail), MemberType = typeof(AvroValidatorTestData))]
+    public async Task ShouldDoThrow_WhenValidateAsync_WhereInvalidDataPassed(string schemaKey, string schema, byte[] msg)
+    {
+        _validator.ParseAndStore(schemaKey, schema);
+
+        await Assert.ThrowsAsync<MemphisSchemaValidationException>(
+             () => _validator.ValidateAsync(msg, schemaKey));
+    }
+
+    [Theory]
+    [MemberData(nameof(AvroValidatorTestData.Message), MemberType = typeof(AvroValidatorTestData))]
+    public async Task ShouldDoThrow_WhenValidateAsync_WhereSchemaNotFoundInCache(byte[] msg)
+    {
+        var nonexistentSchema = Guid.NewGuid().ToString();
+
+        await Assert.ThrowsAsync<MemphisSchemaValidationException>(
+            () => _validator.ValidateAsync(msg, nonexistentSchema));
+    }
+
+    #endregion
+}

--- a/src/Memphis.Client.UnitTests/Validators/TestData/AvroValidatorTestData.cs
+++ b/src/Memphis.Client.UnitTests/Validators/TestData/AvroValidatorTestData.cs
@@ -1,0 +1,75 @@
+﻿using System.ComponentModel;
+using System.Runtime.Serialization;
+using System.Text;
+using SolTechnology.Avro;
+using SolTechnology.Avro.Infrastructure.Attributes;
+
+namespace Memphis.Client.UnitTests;
+
+
+public class ValidUserModel
+{
+    [DataMember(Name = "name")]
+    public string Name { get; set; } = null!;
+
+    [DataMember(Name = "age")]
+    public long Age { get; set; }
+}
+
+public class InvalidUserModel
+{
+
+    [DataMember(Name = "email")]
+    public string Email { get; set; } = null!;
+}
+
+
+public class AvroValidatorTestData
+{
+    public static List<object[]> ValidSchema => new()
+    {
+        new object[] { validUser },
+    };
+
+    public static List<object[]> InvalidSchema => new()
+    {
+        new object[] { invalidSch1 },
+    };
+
+    public static List<object[]> Message => new()
+    {
+        new object[] { validUserData },
+    };
+
+    public static List<object[]> ValidSchemaDetail => new()
+    {
+        new object[] { "valid-simple-msg", validUser, validUserData },
+    };
+
+    public static List<object[]> InvalidSchemaDetail => new()
+    {
+        new object[] { "invalid-simple-msg", validUser, invalidMsg },
+    };
+
+
+    private static readonly string validUser = AvroConvert.GenerateSchema(typeof(ValidUserModel));
+
+
+    private const string invalidSch1 = "This is invalid avro schema";
+
+
+    private readonly static byte[] validUserData = AvroConvert.Serialize(new ValidUserModel
+    {
+        Name = "John Doe",
+        Age = 30
+    });
+
+
+    private readonly static byte[] invalidMsg = AvroConvert.Serialize(new InvalidUserModel
+    {
+        Email = "test@web.com"
+    });
+
+}
+
+

--- a/src/Memphis.Client/Constants/MemphisConstants.cs
+++ b/src/Memphis.Client/Constants/MemphisConstants.cs
@@ -47,8 +47,6 @@ public static class MemphisSchemaTypes
     public const string JSON = "json";
     public const string GRAPH_QL = "graphql";
     public const string PROTO_BUF = "protobuf";
-
-    // currently unsupported
     internal const string AVRO = "avro";
 }
 

--- a/src/Memphis.Client/Helper/MessageSerializer.cs
+++ b/src/Memphis.Client/Helper/MessageSerializer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Memphis.Client.Constants;
+using Memphis.Client.Exception;
+using Newtonsoft.Json;
+using SolTechnology.Avro;
+
+namespace Memphis.Client;
+
+public class MessageSerializer
+{
+    /// <summary>
+    /// Serialize the object to the specified schema type. The supported schema types are: json, graphql, protobuf, avro
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="obj"></param>
+    /// <param name="schemaType"></param>
+    /// <returns></returns>
+    /// <exception cref="MemphisException"></exception>
+    public static byte[] Serialize<T>(T obj, string schemaType) where T : class
+    {
+
+        return schemaType switch
+        {
+            MemphisSchemaTypes.JSON or 
+            MemphisSchemaTypes.GRAPH_QL => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(obj)),
+            MemphisSchemaTypes.PROTO_BUF => SerializeProtoBuf(obj),
+            MemphisSchemaTypes.AVRO => AvroConvert.Serialize(obj),
+            _ => throw new MemphisException("Unsupported schema type, the supported schema types are: json, graphql, protobuf, avro"),
+        };
+
+        static byte[] SerializeProtoBuf<TData>(TData obj) where TData : class
+        {
+            using var stream = new MemoryStream();
+            ProtoBuf.Serializer.Serialize(stream, obj);
+            return stream.ToArray();
+        }
+    }
+}

--- a/src/Memphis.Client/IMemphisClient.cs
+++ b/src/Memphis.Client/IMemphisClient.cs
@@ -9,6 +9,7 @@ using Memphis.Client.Producer;
 using Memphis.Client.Station;
 
 namespace Memphis.Client;
+#pragma warning disable CS8625
 
 public interface IMemphisClient : IDisposable
 {
@@ -127,3 +128,5 @@ public interface IMemphisClient : IDisposable
 
     
 }
+
+#pragma warning restore CS8625

--- a/src/Memphis.Client/Memphis.Client.csproj
+++ b/src/Memphis.Client/Memphis.Client.csproj
@@ -17,6 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AvroConvert" Version="3.3.6" />
       <PackageReference Include="GraphQL" Version="7.2.1" />
       <PackageReference Include="GraphQL.SystemTextJson" Version="7.2.1" />
       <PackageReference Include="NATS.Client" Version="1.0.2" />

--- a/src/Memphis.Client/Producer/MemphisProducer.cs
+++ b/src/Memphis.Client/Producer/MemphisProducer.cs
@@ -142,15 +142,27 @@ public sealed class MemphisProducer : IMemphisProducer
     public async Task ProduceAsync<T>(T message, NameValueCollection headers, int ackWaitMs = 15_000,
         string? messageId = default)
     {
-        string encodedMessage = IsPrimitiveType(message) ?
-            message.ToString() :
-            JsonConvert.SerializeObject(message);
 
         await ProduceAsync(
-            Encoding.UTF8.GetBytes(encodedMessage),
+            SerializeMessage(message),
             headers,
             ackWaitMs,
             messageId);
+
+        byte[] SerializeMessage(T message)
+        {
+            if(IsPrimitiveType(message))
+                return Encoding.UTF8.GetBytes(message.ToString());
+            var schemaType = _memphisClient.GetStationSchemaType(_internalStationName);
+            return schemaType switch
+            {
+                MemphisSchemaTypes.JSON or
+                MemphisSchemaTypes.GRAPH_QL or
+                MemphisSchemaTypes.PROTO_BUF or
+                MemphisSchemaTypes.AVRO => MessageSerializer.Serialize<object>(message!, schemaType),
+                _ => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)),
+            };
+        }
     }
 
     /// <summary>

--- a/src/Memphis.Client/Validators/AvroValidator.cs
+++ b/src/Memphis.Client/Validators/AvroValidator.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using SolTechnology.Avro;
+
+using Memphis.Client.Exception;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace Memphis.Client.Validators;
+
+internal class AnotherUserModel
+{
+    [DataMember(Name = "name")]
+    public string Name { get; set; } = null!;
+
+    [DataMember(Name = "age")]
+    public long Age { get; set; }
+}
+
+internal class AvroValidator : SchemaValidator<string>, ISchemaValidator
+{
+    public Task ValidateAsync(byte[] messageToValidate, string schemaKey)
+    {
+        if (!_schemaCache.TryGetValue(schemaKey, out var schemaObj))
+            throw new MemphisSchemaValidationException($"Schema: {schemaKey} not found in local cache");
+        try
+        {
+            _ = AvroConvert.Avro2Json(messageToValidate, schemaObj);
+            return Task.CompletedTask;
+        }
+        catch (System.Exception exception)
+        {
+            throw new MemphisSchemaValidationException($"Schema validation has failed: \n {exception.Message}", exception);
+        }
+    }
+
+    protected override string Parse(string schemaData, string schemaName)
+    {
+        try
+        {
+            _ = AvroConvert.GenerateModel(schemaData);
+            return schemaData;
+        }
+        catch (System.Exception exception)
+        {
+            throw new MemphisException($"Schema parsing has failed: \n {exception.Message}", exception);
+        }
+    }
+}

--- a/src/Memphis.Client/Validators/ProtoBufValidator.cs
+++ b/src/Memphis.Client/Validators/ProtoBufValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Threading.Tasks;
 using Memphis.Client.Exception;
 
@@ -29,7 +30,7 @@ internal class ProtoBufValidator : SchemaValidator<ProtoBufSchema>, ISchemaValid
         {
             var result = await ProtoBufEval.ProtoBufValidator.Validate(
                 base64Data: Convert.ToBase64String(messageToValidate), 
-                activeSchemaVersion: protoBufSchema.ActiveSchemaVersion, 
+                activeSchemaVersion: Convert.ToBase64String(Encoding.UTF8.GetBytes(protoBufSchema.ActiveSchemaVersion)), 
                 schemaName: protoBufSchema.SchemaName);
             if(result.HasError)
                 throw new MemphisSchemaValidationException($"Schema validation has failed: \n {result.Error}");

--- a/src/Memphis.Client/Validators/ValidatorType.cs
+++ b/src/Memphis.Client/Validators/ValidatorType.cs
@@ -4,6 +4,7 @@
     {
         GRAPHQL = 1,
         JSON = 2,
-        PROTOBUF = 3
+        PROTOBUF = 3,
+        AVRO = 4
     }
 }

--- a/src/ProtoBufEval.Tests/ProtoBufValidatorTests.cs
+++ b/src/ProtoBufEval.Tests/ProtoBufValidatorTests.cs
@@ -1,48 +1,102 @@
+using ProtoBuf;
+using System.Text;
+
 namespace ProtoBufEval.Tests;
+
+
+
+[ProtoContract]
+public class Test
+{
+
+    [ProtoMember(1, Name = @"field1")]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string Field1 { get; set; } = "";
+
+    [ProtoMember(2, Name = @"field2")]
+    [System.ComponentModel.DefaultValue("")]
+    public string Field2 { get; set; } = "";
+
+    [ProtoMember(3, Name = @"field3")]
+    public int Field3 { get; set; }
+
+}
+
+
+[ProtoContract]
+public class InvalidTestModel
+{
+
+    [ProtoMember(1, Name = @"field1")]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string Field1 { get; set; } = "";
+
+    [ProtoMember(3, Name = @"field3")]
+    public int Field3 { get; set; }
+
+}
 
 public class ProtoBufValidatorTests
 {
-    // [Theory]
-    // [InlineData(
-    //     "c3lzdGVtID0gInByb3RvMyI7CgpkYXRhYmFzZSBleGFtcGxlOwpfbWFpbk1lc3NhZ2UgUGVyc29uIHsKICBuYW1lID0gMTsKICBpbnQzMiBhZ2UgPSAyOwoKICBzdHJpbmcgZW1haWwgPSAzOwp9Cg==",
-    //     """
-    //     {
-    //         "version_number": 1,
-    //         "descriptor": "\nf\n\u000cprt2_1.proto\"N\n\u0004Test\u0012\u0016\n\u0006field1\u0018\u0001 \u0001(\tR\u0006field1\u0012\u0016\n\u0006field2\u0018\u0002 \u0001(\tR\u0006field2\u0012\u0016\n\u0006field3\u0018\u0003 \u0001(\u0005R\u0006field3b\u0006proto3",
-    //         "schema_content": "syntax = \"proto3\";\nmessage Test {\n    string field1 = 1;\n    string  field2 = 2;\n    int32  field3 = 3;\n}",
-    //         "message_struct_name": "Test"
-    //     }
-    //     """,
-    //     "prt2"
-    // )]
-    // public async Task GivenValidPayload_WhenValidate_ThenNoError(string base64Data, string activeSchemaVersion, string schemaName)
-    // {
-    //     var result = await ProtoBufValidator.Validate(base64Data, activeSchemaVersion, schemaName);
-
-
-    //     Assert.False(result.HasError);
-    //     Assert.Null(result.Error);
-    // }
-
     [Theory]
     [InlineData(
-        "c3lzdGVtID0gInByb3RvMyI7CgpkYXRhYmFzZSBleGFtcGxlOwpfbWFpbk1lc3NhZ2UgUGVyc29uIHsKICBuYW1lID0gMTsKICBpbnQzMiBhZ2UgPSAyOwoKICBzdHJpbmcgZW1haWwgPSAzOwp9Cg==",
         """
         {
-            "version_number": 1,
-            "descriptor": "\nf\n\u000cprt2_1.proto\"N\n\u0004Test\u0012\u0016\n\u0006field1\u0018\u0001 \u0001(\tR\u0006field1\u0012\u0016\n\u0006field2\u0018\u0002 \u0001(\tR\u0006field2\u0012\u0016\n\u0006field3\u0018\u0003 \u0001(\u0005R\u0006field3b\u0006proto3",
-            "schema_content": "syntax = \"proto3\";\nmessage Test {\n    string field1 = 1;\n    string  field2 = 2;\n    int32  field3 = 3;\n}",
+            "version_number": 1, 
+            "descriptor": "CmsKEXNhbXBsZXBiZl8xLnByb3RvIk4KBFRlc3QSFgoGZmllbGQxGAEgASgJUgZmaWVsZDESFgoGZmllbGQyGAIgASgJUgZmaWVsZDISFgoGZmllbGQzGAMgASgFUgZmaWVsZDNiBnByb3RvMw==", 
+            "schema_content": "syntax = \"proto3\";\nmessage Test {\n    string field1 = 1;\n    string  field2 = 2;\n    int32  field3 = 3;\n}", 
             "message_struct_name": "Test"
         }
         """,
-        "prt2"
+        "samplepbf"
     )]
-    public async Task GivenInvalidPayload_WhenValidate_ThenHasError(string base64Data, string activeSchemaVersion, string schemaName)
+    public async Task GivenValidPayload_WhenValidate_ThenNoError(string activeSchemaVersion, string schemaName)
     {
-        var result  = await ProtoBufValidator.Validate(base64Data, activeSchemaVersion, schemaName);
+        var validData = new Test
+        {
+            Field1 = "AwesomeFirst",
+            Field2 = "SecondField",
+            Field3 = 333,
+        };
+        var base64ValidData = ConvertProtoBufToBase64(validData);
+        var activeSchemaVersionBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(activeSchemaVersion));
+
+        var result = await ProtoBufValidator.Validate(base64ValidData, activeSchemaVersionBase64, schemaName);
+
+        Assert.False(result.HasError);
+        Assert.Null(result.Error);
+    }
+
+    [Theory]
+    [InlineData(
+        """
+        {
+            "version_number": 1, 
+            "descriptor": "CmsKEXNhbXBsZXBiZl8xLnByb3RvIk4KBFRlc3QSFgoGZmllbGQxGAEgASgJUgZmaWVsZDESFgoGZmllbGQyGAIgASgJUgZmaWVsZDISFgoGZmllbGQzGAMgASgFUgZmaWVsZDNiBnByb3RvMw==", 
+            "schema_content": "syntax = \"proto3\";\nmessage Test {\n    string field1 = 1;\n    string  field2 = 2;\n    int32  field3 = 3;\n}", 
+            "message_struct_name": "Test"
+        }
+        """,
+        "samplepbf"
+    )]
+    public async Task GivenInvalidPayload_WhenValidate_ThenHasError(string activeSchemaVersion, string schemaName)
+    {
+        var base64InvalidData = Convert.ToBase64String(Encoding.UTF8.GetBytes("CgJmb3JtYWwxCgRmZWlsZDIKCAk="));
+        var activeSchemaVersionBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(activeSchemaVersion));
+
+        var result = await ProtoBufValidator.Validate(base64InvalidData, activeSchemaVersionBase64, schemaName);
 
 
         Assert.True(result.HasError);
         Assert.NotNull(result.Error);
+    }
+
+
+
+    private static string ConvertProtoBufToBase64<TData>(TData obj) where TData : class
+    {
+        using var stream = new MemoryStream();
+        ProtoBuf.Serializer.Serialize(stream, obj);
+        return Convert.ToBase64String(stream.ToArray());
     }
 }

--- a/src/ProtoBufEval/ProtoBufValidator.cs
+++ b/src/ProtoBufEval/ProtoBufValidator.cs
@@ -33,16 +33,16 @@ public static class ProtoBufValidator
     /// Validate a base64 encoded protobuf payload against a schema
     /// </summary>
     /// <param name="base64Data"></param>
-    /// <param name="activeSchemaVersion"></param>
+    /// <param name="activeSchemaVersionBase64"></param>
     /// <param name="schemaName"></param>
     /// <returns></returns>
-    public static async Task<ProtoBufValidationResult> Validate(string base64Data, string activeSchemaVersion, string schemaName)
+    public static async Task<ProtoBufValidationResult> Validate(string base64Data, string activeSchemaVersionBase64, string schemaName)
     {
         var result = await Cli.Wrap(_nativeBinary)
             .WithArguments(new[] {
                 "eval",
                 "--payload",base64Data,
-                "--schema", activeSchemaVersion,
+                "--schema", activeSchemaVersionBase64,
                 "--schema-name", schemaName
             })
             .WithValidation(CommandResultValidation.None)


### PR DESCRIPTION
This PR includes these changes:
- All `protoeval` arguments are now base64
- Descriptor is updated from plain string into base64
- Additional unit test for `ProtoBufEval`