### PR TITLE
bugfix-RND-294-creating-a-schema-from-the-sdk-doesnt-creating-new-version-if-the-schema-already-exist

### DIFF
--- a/src/Memphis.Client/MemphisClient.cs
+++ b/src/Memphis.Client/MemphisClient.cs
@@ -498,7 +498,7 @@ public sealed partial class MemphisClient : IMemphisClient
             try
             {
                 var response = (CreateSchemaResponse)JsonSerDes.PrepareObjectFromString<CreateSchemaResponse>(responseStr);
-                if (!string.IsNullOrWhiteSpace(response.Error))
+                if (!string.IsNullOrWhiteSpace(response.Error) && !response.Error.Contains("already exist"))
                     throw new MemphisException(response.Error);
             }
             catch (System.Exception e) when (e is not MemphisException)

--- a/src/Memphis.Client/MemphisClient.cs
+++ b/src/Memphis.Client/MemphisClient.cs
@@ -498,7 +498,7 @@ public sealed partial class MemphisClient : IMemphisClient
             try
             {
                 var response = (CreateSchemaResponse)JsonSerDes.PrepareObjectFromString<CreateSchemaResponse>(responseStr);
-                if (!string.IsNullOrWhiteSpace(response.Error) && !response.Error.Contains("already exist"))
+                if (!string.IsNullOrWhiteSpace(response.Error) && !response.Error.Contains("already exists"))
                     throw new MemphisException(response.Error);
             }
             catch (System.Exception e) when (e is not MemphisException)


### PR DESCRIPTION
…ema-already-exist