### PR TITLE
Bug fixes  & Refactoring

### DIFF
--- a/src/Memphis.Client.IntegrationTests/FullFlowTests.cs
+++ b/src/Memphis.Client.IntegrationTests/FullFlowTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Text;
 using Memphis.Client.Consumer;
 using Memphis.Client.Producer;
@@ -201,9 +202,11 @@ file static class Extensions
             args.MessageList.ForEach(msg => msg.Ack());
         };
 
-        _ = consumer1.ConsumeAsync(new ConsumeOptions { PartitionKey = partitionKey });
-        _ = consumer2.ConsumeAsync(new ConsumeOptions { PartitionKey = partitionKey });
-        await Task.Delay(TimeSpan.FromSeconds(10));
+        await Task.WhenAny(
+            consumer1.ConsumeAsync(new ConsumeOptions { PartitionKey = partitionKey }),
+            consumer2.ConsumeAsync(new ConsumeOptions { PartitionKey = partitionKey }),
+            Task.Delay(TimeSpan.FromSeconds(30)));
+            
         return count;
     }
 }

--- a/src/Memphis.Client.UnitTests/AvroValidatorTest.cs
+++ b/src/Memphis.Client.UnitTests/AvroValidatorTest.cs
@@ -1,17 +1,11 @@
-﻿using System.Collections.Concurrent;
-using System.Text;
-using GraphQL.Types;
+﻿using Memphis.Client.Constants;
 using Memphis.Client.Exception;
-using Memphis.Client.UnitTests.Validators.TestData;
 using Memphis.Client.Validators;
-using Xunit;
 
 namespace Memphis.Client.UnitTests.Validators;
 
 public class AvroValidatorTest
 {
-
-
     private readonly ISchemaValidator _validator;
 
     public AvroValidatorTest()
@@ -24,7 +18,13 @@ public class AvroValidatorTest
     [MemberData(nameof(AvroValidatorTestData.ValidSchema), MemberType = typeof(AvroValidatorTestData))]
     public void ShouldReturnTrue_WhenParseAndStore_WhereValidSchemaPassed(string validSchema)
     {
-        var actual = _validator.ParseAndStore("vaid-schema-001", validSchema);
+        var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+            "valid-schema-001",
+            validSchema,
+            MemphisSchemaTypes.AVRO
+        );
+
+        var actual = _validator.AddOrUpdateSchema(schemaUpdate);
 
         Assert.True(actual);
     }
@@ -34,7 +34,13 @@ public class AvroValidatorTest
     [MemberData(nameof(AvroValidatorTestData.InvalidSchema), MemberType = typeof(AvroValidatorTestData))]
     public void ShouldReturnFalse_WhenParseAndStore_WhereInvalidSchemaPassed(string invalidSchema)
     {
-        var actual = _validator.ParseAndStore("invalid-schema-001", invalidSchema);
+        var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+            "invalid-schema-001",
+            invalidSchema,
+            MemphisSchemaTypes.AVRO
+        );
+
+        var actual = _validator.AddOrUpdateSchema(schemaUpdate);
 
         Assert.False(actual);
     }
@@ -48,10 +54,16 @@ public class AvroValidatorTest
     [MemberData(nameof(AvroValidatorTestData.ValidSchemaDetail), MemberType = typeof(AvroValidatorTestData))]
     public async Task ShouldDoSuccess_WhenValidateAsync_WhereValidDataPassed(string schemaKey, string schema, byte[] msg)
     {
-        _validator.ParseAndStore(schemaKey, schema);
+        var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+            schemaKey,
+            schema,
+            MemphisSchemaTypes.AVRO
+        );
+
+        _validator.AddOrUpdateSchema(schemaUpdate);
 
         var exception = await Record.ExceptionAsync(async () => await _validator.ValidateAsync(msg, schemaKey));
-        
+
         Assert.Null(exception);
     }
 
@@ -59,7 +71,13 @@ public class AvroValidatorTest
     [MemberData(nameof(AvroValidatorTestData.InvalidSchemaDetail), MemberType = typeof(AvroValidatorTestData))]
     public async Task ShouldDoThrow_WhenValidateAsync_WhereInvalidDataPassed(string schemaKey, string schema, byte[] msg)
     {
-        _validator.ParseAndStore(schemaKey, schema);
+        var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+            schemaKey,
+            schema,
+            MemphisSchemaTypes.AVRO
+        );
+
+        _validator.AddOrUpdateSchema(schemaUpdate);
 
         await Assert.ThrowsAsync<MemphisSchemaValidationException>(
              () => _validator.ValidateAsync(msg, schemaKey));

--- a/src/Memphis.Client.UnitTests/MemphisClientTest.cs
+++ b/src/Memphis.Client.UnitTests/MemphisClientTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Text;
 using System.Threading.Tasks;
+using Memphis.Client.Constants;
 using Memphis.Client.Exception;
 using Memphis.Client.Models.Response;
 using Memphis.Client.Validators;
@@ -135,7 +136,7 @@ namespace Memphis.Client.UnitTests
             schemaUpdateDictionaryMock.TryAdd(internalStationNameForGraphql, new SchemaUpdateInit()
             {
                 SchemaName = "test-schema-01",
-                SchemaType = SchemaUpdateInit.SchemaTypes.GRAPHQL,
+                SchemaType = MemphisSchemaTypes.GRAPH_QL,
                 ActiveVersion = new ProducerSchemaUpdateVersion()
                 {
                     Content = graphqlSchemaStr,

--- a/src/Memphis.Client.UnitTests/Validators/GraphqlValidatorTest.cs
+++ b/src/Memphis.Client.UnitTests/Validators/GraphqlValidatorTest.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Concurrent;
-using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 using GraphQL.Types;
+using Memphis.Client.Constants;
 using Memphis.Client.Exception;
 using Memphis.Client.Validators;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Memphis.Client.UnitTests.Validators
@@ -34,9 +32,14 @@ namespace Memphis.Client.UnitTests.Validators
                    sayHello : String
                   }
              ";
+            var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+                "test-schema-001",
+                schemaStr,
+                MemphisSchemaTypes.GRAPH_QL
+            );
             // when:
 
-            var actual = _sut.ParseAndStore("test-schema-001", schemaStr);
+            var actual = _sut.AddOrUpdateSchema(schemaUpdate);
 
             // then:
 
@@ -52,9 +55,15 @@ namespace Memphis.Client.UnitTests.Validators
                    sayHelwlo : String
                   }
              ";
+
+            var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+                "test-schema-001",
+                schemaStr,
+                MemphisSchemaTypes.GRAPH_QL
+            );
             // when:
 
-            var actual = _sut.ParseAndStore("test-schema-001", schemaStr);
+            var actual = _sut.AddOrUpdateSchema(schemaUpdate);
 
             // then:
 

--- a/src/Memphis.Client.UnitTests/Validators/JsonValidatorTest.cs
+++ b/src/Memphis.Client.UnitTests/Validators/JsonValidatorTest.cs
@@ -1,11 +1,7 @@
-using System.Collections.Concurrent;
-using System.Text;
-using GraphQL.Types;
+using Memphis.Client.Constants;
 using Memphis.Client.Exception;
 using Memphis.Client.UnitTests.Validators.TestData;
 using Memphis.Client.Validators;
-using NJsonSchema;
-using Xunit;
 
 namespace Memphis.Client.UnitTests.Validators
 {
@@ -20,10 +16,16 @@ namespace Memphis.Client.UnitTests.Validators
 
         #region JsonValidatorTest.ParseAndStore
         [Theory]
-        [MemberData(nameof(JsonValidatorTestData.ValidSchema),MemberType = typeof(JsonValidatorTestData))]
+        [MemberData(nameof(JsonValidatorTestData.ValidSchema), MemberType = typeof(JsonValidatorTestData))]
         public void ShouldReturnTrue_WhenParseAndStore_WhereValidSchemaPassed(string validSchema)
         {
-            var actual = _sut.ParseAndStore("test-schema-001", validSchema);
+            var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+                "test-schema-001",
+                validSchema,
+                MemphisSchemaTypes.JSON
+            );
+
+            var actual = _sut.AddOrUpdateSchema(schemaUpdate);
 
             Assert.True(actual);
         }
@@ -33,7 +35,13 @@ namespace Memphis.Client.UnitTests.Validators
         [MemberData(nameof(JsonValidatorTestData.InvalidSchema), MemberType = typeof(JsonValidatorTestData))]
         public void ShouldReturnFalse_WhenParseAndStore_WhereInvalidSchemaPassed(string invalidSchema)
         {
-            var actual = _sut.ParseAndStore("test-schema-001", invalidSchema);
+            var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+                "test-schema-001",
+                invalidSchema,
+                MemphisSchemaTypes.JSON
+            );
+
+            var actual = _sut.AddOrUpdateSchema(schemaUpdate);
 
             Assert.False(actual);
         }
@@ -45,21 +53,33 @@ namespace Memphis.Client.UnitTests.Validators
 
         [Theory]
         [MemberData(nameof(JsonValidatorTestData.ValidSchemaDetail), MemberType = typeof(JsonValidatorTestData))]
-        public async Task ShouldDoSuccess_WhenValidateAsync_WhereValidDataPassed(string schemaKey,string schema, byte[] msg)
+        public async Task ShouldDoSuccess_WhenValidateAsync_WhereValidDataPassed(string schemaKey, string schema, byte[] msg)
         {
-            _sut.ParseAndStore(schemaKey, schema);
+            var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+                schemaKey,
+                schema,
+                MemphisSchemaTypes.JSON
+            );
+
+            _sut.AddOrUpdateSchema(schemaUpdate);
 
             await _sut.ValidateAsync(msg, schemaKey);
         }
 
         [Theory]
         [MemberData(nameof(JsonValidatorTestData.InvalidSchemaDetail), MemberType = typeof(JsonValidatorTestData))]
-        public async Task ShouldDoThrow_WhenValidateAsync_WhereInvalidDataPassed(string schemaKey,string schema, byte[] msg)
+        public async Task ShouldDoThrow_WhenValidateAsync_WhereInvalidDataPassed(string schemaKey, string schema, byte[] msg)
         {
-            _sut.ParseAndStore(schemaKey, schema);
+            var schemaUpdate = ValidatorTestHelper.GetSchemaUpdateInit(
+                schemaKey,
+                schema,
+                MemphisSchemaTypes.JSON
+            );
 
-             await Assert.ThrowsAsync<MemphisSchemaValidationException>(
-                  () => _sut.ValidateAsync(msg, schemaKey));
+            _sut.AddOrUpdateSchema(schemaUpdate);
+
+            await Assert.ThrowsAsync<MemphisSchemaValidationException>(
+                 () => _sut.ValidateAsync(msg, schemaKey));
         }
 
         [Theory]

--- a/src/Memphis.Client.UnitTests/Validators/ValidatorTestHelper.cs
+++ b/src/Memphis.Client.UnitTests/Validators/ValidatorTestHelper.cs
@@ -1,0 +1,27 @@
+using Memphis.Client.Constants;
+using Memphis.Client.Models.Response;
+
+namespace Memphis.Client.UnitTests.Validators;
+
+internal class ValidatorTestHelper
+{
+    public static SchemaUpdateInit GetSchemaUpdateInit(
+        string schemaName,
+        string schema,
+        string schemaType
+    )
+    {
+        return new SchemaUpdateInit
+        {
+            SchemaName = schemaName,
+            ActiveVersion = new ProducerSchemaUpdateVersion
+            {
+                VersionNumber = "1",
+                Descriptor = string.Empty,
+                Content = schema,
+                MessageStructName = string.Empty
+            },
+            SchemaType = schemaType
+        };
+    }
+}

--- a/src/Memphis.Client/Constants/MemphisConstants.cs
+++ b/src/Memphis.Client/Constants/MemphisConstants.cs
@@ -1,3 +1,5 @@
+using Memphis.Client.Validators;
+
 namespace Memphis.Client.Constants;
 internal class MemphisStations
 {
@@ -42,6 +44,18 @@ internal static class MemphisSchemaTypes
     public const string GRAPH_QL = "graphql";
     public const string PROTO_BUF = "protobuf";
     internal const string AVRO = "avro";
+
+    internal static ValidatorType ToValidator(this string schemaType)
+    {
+        return schemaType switch
+        {
+            JSON => ValidatorType.JSON,
+            GRAPH_QL => ValidatorType.GRAPHQL,
+            PROTO_BUF => ValidatorType.PROTOBUF,
+            AVRO => ValidatorType.AVRO,
+            _ => throw new MemphisException($"Schema type: {schemaType} is not supported")
+        };
+    }
 }
 
 internal static class MemphisSdkClientUpdateTypes

--- a/src/Memphis.Client/Constants/MemphisConstants.cs
+++ b/src/Memphis.Client/Constants/MemphisConstants.cs
@@ -31,16 +31,11 @@ internal class MemphisSubjects
     public const string SDK_CLIENTS_UPDATE = "$memphis_sdk_clients_updates";
     public const string MEMPHIS_SCHEMA_VERSE_DLS = "$memphis_schemaverse_dls";
     public const string SCHEMA_CREATION = "$memphis_schema_creations";
-
-    // not available yes
-    public const string SCHEMA_DESTRUCTION = "";
-
     public const string FUNCTIONS_UPDATE = "$memphis_functions_updates_";
-
     public const string NACKED_DLS = "$memphis_nacked_dls";
 }
 
-public static class MemphisSchemaTypes
+internal static class MemphisSchemaTypes
 {
     public const string NONE = "";
     public const string JSON = "json";
@@ -68,7 +63,6 @@ internal static class MemphisRequestVersions
 {
     public const int LastProducerCreationRequestVersion = 4;
     public const int LastProducerDestroyRequestVersion = 1;
-
     public const int LastConsumerCreationRequestVersion = 4;
     public const int LastConsumerDestroyRequestVersion = 1;
 }

--- a/src/Memphis.Client/Consumer/IMemphisConsumer.cs
+++ b/src/Memphis.Client/Consumer/IMemphisConsumer.cs
@@ -1,6 +1,4 @@
-﻿using Memphis.Client.Core;
-
-namespace Memphis.Client.Consumer;
+﻿namespace Memphis.Client.Consumer;
 
 public interface IMemphisConsumer : IDisposable
 {
@@ -43,6 +41,3 @@ public interface IMemphisConsumer : IDisposable
     /// <returns></returns>
     Task DestroyAsync(int timeoutRetry = 5);
 }
-
-
-

--- a/src/Memphis.Client/Consumer/MemphisConsumer.cs
+++ b/src/Memphis.Client/Consumer/MemphisConsumer.cs
@@ -408,6 +408,9 @@ public sealed class MemphisConsumer : IMemphisConsumer
                 _consumerOptions,
                 partitionNumber
             ));
+            
+            if (memphisMessages is null || !memphisMessages.Any())
+                return;
 
             MessageReceived?.Invoke(this, new MemphisMessageHandlerEventArgs(memphisMessages, consumerContext, null));
         }

--- a/src/Memphis.Client/Consumer/MemphisConsumer.cs
+++ b/src/Memphis.Client/Consumer/MemphisConsumer.cs
@@ -6,10 +6,8 @@ public sealed class MemphisConsumer : IMemphisConsumer
 {
     public event EventHandler<MemphisMessageHandlerEventArgs> MessageReceived;
     public event EventHandler<MemphisMessageHandlerEventArgs> DlsMessageReceived;
-
     internal string InternalStationName { get; private set; }
     internal string Key => $"{InternalStationName}_{_consumerOptions.RealName}";
-
     private ISyncSubscription _dlsSubscription;
     private readonly MemphisClient _memphisClient;
     private readonly MemphisConsumerOptions _consumerOptions;
@@ -18,13 +16,11 @@ public sealed class MemphisConsumer : IMemphisConsumer
     private readonly CancellationTokenSource _cancellationTokenSource;
     private bool _subscriptionActive;
     private readonly int _pingConsumerIntervalMs;
-
     /// <summary>
     /// Messages in DLS station will have a partition number of -1. This does not indicate the actual partition number of the message.
     /// Instead, it indicates that the message is in the DLS station.
     /// </summary>
     private const int DlsMessagePartitionNumber = -1;
-
     private int[] _partitions;
     internal StationPartitionResolver PartitionResolver { get; set; }
     internal int[] Partitions

--- a/src/Memphis.Client/MemphisClient.Consumer.cs
+++ b/src/Memphis.Client/MemphisClient.Consumer.cs
@@ -1,0 +1,123 @@
+using Memphis.Client.Consumer;
+
+namespace Memphis.Client;
+
+public partial class MemphisClient
+{
+    /// <summary>
+    /// Create Consumer for station 
+    /// </summary>
+    /// <param name="consumerOptions">options used to customize the behaviour of consumer</param>
+    /// <returns>An <see cref="MemphisConsumer"/> object connected to the station from consuming data</returns>
+    public async Task<MemphisConsumer> CreateConsumer(MemphisConsumerOptions consumerOptions, int timeoutRetry = 5, CancellationToken cancellationToken = default)
+    {
+        EnsureBatchSizeIsValid(consumerOptions.BatchSize);
+
+        if (_brokerConnection.IsClosed())
+        {
+            throw MemphisExceptions.DeadConnectionException;
+        }
+
+        consumerOptions.RealName = consumerOptions.ConsumerName.ToLower();
+
+        if (consumerOptions.GenerateUniqueSuffix)
+        {
+            consumerOptions.ConsumerName = $"{consumerOptions.ConsumerName}_{MemphisUtil.GetUniqueKey(8)}";
+        }
+
+        if (string.IsNullOrEmpty(consumerOptions.ConsumerGroup))
+        {
+            consumerOptions.ConsumerGroup = consumerOptions.ConsumerName;
+        }
+
+        try
+        {
+            var createConsumerModel = new CreateConsumerRequest
+            {
+                ConsumerName = consumerOptions.ConsumerName,
+                StationName = consumerOptions.StationName,
+                ConnectionId = _connectionId,
+                ConsumerType = "application",
+                ConsumerGroup = consumerOptions.ConsumerGroup,
+                MaxAckTimeMs = consumerOptions.MaxAckTimeMs,
+                MaxMsgCountForDelivery = consumerOptions.MaxMsgDeliveries,
+                UserName = _userName,
+                StartConsumeFromSequence = consumerOptions.StartConsumeFromSequence,
+                LastMessages = consumerOptions.LastMessages,
+                RequestVersion = MemphisRequestVersions.LastConsumerCreationRequestVersion,
+                ApplicationId = ApplicationId,
+                SdkLang = ".NET"
+            };
+
+            var createConsumerModelJson = JsonSerDes.PrepareJsonString<CreateConsumerRequest>(createConsumerModel);
+
+            byte[] createConsumerReqBytes = Encoding.UTF8.GetBytes(createConsumerModelJson);
+
+            Msg createConsumerResp = await RequestAsync(MemphisStations.MEMPHIS_CONSUMER_CREATIONS, createConsumerReqBytes, timeoutRetry, cancellationToken);
+            var responseStr = Encoding.UTF8.GetString(createConsumerResp.Data);
+            var createConsumerResponse = JsonConvert.DeserializeObject<CreateConsumerResponse>(responseStr);
+
+            if (createConsumerResponse is null)
+            {
+                if (!string.IsNullOrEmpty(responseStr))
+                {
+                    throw new MemphisException(responseStr);
+                }
+
+                var oldconsumer = new MemphisConsumer(this, consumerOptions);
+                _consumerCache.AddOrUpdate(oldconsumer.Key, oldconsumer, (_, _) => oldconsumer);
+
+                return oldconsumer;
+            }
+            if (!string.IsNullOrEmpty(createConsumerResponse.Error))
+            {
+                throw new MemphisException(responseStr);
+            }
+
+            var consumer = new MemphisConsumer(this, consumerOptions, createConsumerResponse.PartitionsUpdate.PartitionsList);
+            _consumerCache.AddOrUpdate(consumer.Key, consumer, (_, _) => consumer);
+
+            await ListenForSchemaUpdate(consumerOptions.StationName);
+
+            return consumer;
+
+        }
+        catch (MemphisException)
+        {
+            throw;
+        }
+        catch (System.Exception e)
+        {
+            throw MemphisExceptions.FailedToCreateConsumerException(e);
+        }
+    }
+
+    /// <summary>
+    /// Create a new consumer
+    /// </summary>
+    /// <param name="fetchMessageOptions">Fetch message options</param>
+    /// <returns>MemphisConsumer</returns>
+    public async Task<MemphisConsumer> CreateConsumer(FetchMessageOptions fetchMessageOptions, int timeoutRetry = 5, CancellationToken cancellationToken = default)
+    {
+        return await CreateConsumer(new MemphisConsumerOptions
+        {
+            StationName = fetchMessageOptions.StationName,
+            ConsumerName = fetchMessageOptions.ConsumerName,
+            ConsumerGroup = fetchMessageOptions.ConsumerGroup,
+            BatchSize = fetchMessageOptions.BatchSize,
+            BatchMaxTimeToWaitMs = fetchMessageOptions.BatchMaxTimeToWaitMs,
+            MaxAckTimeMs = fetchMessageOptions.MaxAckTimeMs,
+            MaxMsgDeliveries = fetchMessageOptions.MaxMsgDeliveries,
+            GenerateUniqueSuffix = fetchMessageOptions.GenerateUniqueSuffix,
+            StartConsumeFromSequence = fetchMessageOptions.StartConsumeFromSequence,
+            LastMessages = fetchMessageOptions.LastMessages,
+        }, timeoutRetry, cancellationToken);
+    }
+
+    internal IConsumerContext GetConsumerContext(string streamName, string durableName)
+    {
+        var streamContext = _brokerConnection.GetStreamContext(streamName);
+        var consumerContext = streamContext.GetConsumerContext(durableName);
+        return consumerContext;
+    }
+}

--- a/src/Memphis.Client/MemphisClient.cs
+++ b/src/Memphis.Client/MemphisClient.cs
@@ -297,15 +297,15 @@ public sealed partial class MemphisClient : IMemphisClient
     private async Task RemoveFromSchemaUpdateListener(string stationName)
     {
         var internalStationName = MemphisUtil.GetInternalName(stationName);
-        if (_stationSchemaUpdateListeners.TryGetValue(internalStationName, out int updateListenrsCount))
+        if (_stationSchemaUpdateListeners.TryGetValue(internalStationName, out int updateListenersCount))
         {
-            if (updateListenrsCount == 0)
+            if (updateListenersCount == 0)
             {
                 return;
             }
 
-            var updateListenerCountAfterRemove = updateListenrsCount - 1;
-            _stationSchemaUpdateListeners.TryUpdate(internalStationName, updateListenerCountAfterRemove, updateListenrsCount);
+            var updateListenerCountAfterRemove = updateListenersCount - 1;
+            _stationSchemaUpdateListeners.TryUpdate(internalStationName, updateListenerCountAfterRemove, updateListenersCount);
 
             if (updateListenerCountAfterRemove <= 0)
             {
@@ -460,11 +460,8 @@ public sealed partial class MemphisClient : IMemphisClient
         var validatorType = MemphisSchemaTypes.ToValidator(schemaUpdate.SchemaType);
         if (_schemaValidators.TryGetValue(validatorType, out ISchemaValidator schemaValidatorCache))
         {
-            var parsedAndStored = validatorType == ValidatorType.PROTOBUF
-                ? schemaValidatorCache.ParseAndStore(schemaUpdate.SchemaName, JsonConvert.SerializeObject(schemaUpdate.ActiveVersion))
-                : schemaValidatorCache.ParseAndStore(schemaUpdate.SchemaName, schemaUpdate.ActiveVersion?.Content);
-
-            if (!parsedAndStored)
+            var schemaStored = schemaValidatorCache.AddOrUpdateSchema(schemaUpdate);
+            if (!schemaStored)
             {
                 //TODO raise notification regarding unable to parse schema pushed by Memphis
                 throw new InvalidOperationException($"Unable to parse and store " +

--- a/src/Memphis.Client/MemphisClient.cs
+++ b/src/Memphis.Client/MemphisClient.cs
@@ -539,7 +539,7 @@ public sealed partial class MemphisClient : IMemphisClient
         {
             switch (schemaUpdateInit.SchemaType)
             {
-                case SchemaUpdateInit.SchemaTypes.JSON:
+                case MemphisSchemaTypes.JSON:
                     {
                         if (_schemaValidators.TryGetValue(ValidatorType.JSON, out ISchemaValidator schemaValidator))
                         {
@@ -548,7 +548,7 @@ public sealed partial class MemphisClient : IMemphisClient
 
                         break;
                     }
-                case SchemaUpdateInit.SchemaTypes.GRAPHQL:
+                case MemphisSchemaTypes.GRAPH_QL:
                     {
                         if (_schemaValidators.TryGetValue(ValidatorType.GRAPHQL, out ISchemaValidator schemaValidator))
                         {
@@ -557,7 +557,7 @@ public sealed partial class MemphisClient : IMemphisClient
 
                         break;
                     }
-                case SchemaUpdateInit.SchemaTypes.PROTOBUF:
+                case MemphisSchemaTypes.PROTO_BUF:
                     {
                         if (_schemaValidators.TryGetValue(ValidatorType.PROTOBUF, out ISchemaValidator schemaValidator))
                         {
@@ -787,7 +787,7 @@ public sealed partial class MemphisClient : IMemphisClient
 
         switch (schemaUpdate.SchemaType)
         {
-            case SchemaUpdateInit.SchemaTypes.JSON:
+            case MemphisSchemaTypes.JSON:
                 {
                     if (_schemaValidators.TryGetValue(ValidatorType.JSON, out ISchemaValidator schemaValidator))
                     {
@@ -806,7 +806,7 @@ public sealed partial class MemphisClient : IMemphisClient
 
                     break;
                 }
-            case SchemaUpdateInit.SchemaTypes.GRAPHQL:
+            case MemphisSchemaTypes.GRAPH_QL:
                 {
                     if (_schemaValidators.TryGetValue(ValidatorType.GRAPHQL, out ISchemaValidator schemaValidator))
                     {
@@ -825,7 +825,7 @@ public sealed partial class MemphisClient : IMemphisClient
 
                     break;
                 }
-            case SchemaUpdateInit.SchemaTypes.PROTOBUF:
+            case MemphisSchemaTypes.PROTO_BUF:
                 {
                     if (_schemaValidators.TryGetValue(ValidatorType.PROTOBUF, out ISchemaValidator schemaValidator))
                     {

--- a/src/Memphis.Client/MemphisClient.cs
+++ b/src/Memphis.Client/MemphisClient.cs
@@ -1025,6 +1025,10 @@ public sealed partial class MemphisClient : IMemphisClient
                     }
                 }
             }
+            catch when (!IsConnected())
+            {
+                // Connection is closed   
+            }
             catch (System.Exception exception)
             {
                 throw new MemphisException(exception.Message, exception);

--- a/src/Memphis.Client/Models/Response/SchemaUpdateInit.cs
+++ b/src/Memphis.Client/Models/Response/SchemaUpdateInit.cs
@@ -13,11 +13,4 @@ internal sealed class SchemaUpdateInit
 
     [DataMember(Name = "type")]
     public string SchemaType { get; set; }
-    
-    internal static class SchemaTypes
-    {
-        public const string PROTOBUF = "protobuf";
-        public const string JSON = "json";
-        public const string GRAPHQL = "graphql";
-    }
 }

--- a/src/Memphis.Client/Validators/AvroValidator.cs
+++ b/src/Memphis.Client/Validators/AvroValidator.cs
@@ -28,7 +28,26 @@ internal class AvroValidator : SchemaValidator<string>, ISchemaValidator
         }
     }
 
-    protected override string Parse(string schemaData, string schemaName)
+    public bool AddOrUpdateSchema(SchemaUpdateInit schemaUpdate)
+    {
+        if (!IsSchemaUpdateValid(schemaUpdate))
+            return false;
+
+        try
+        {
+            var schemeName = schemaUpdate.SchemaName;
+            var schemaData = schemaUpdate.ActiveVersion.Content;
+            var newSchema = Parse(schemaData, schemeName);
+            _schemaCache.AddOrUpdate(schemeName, newSchema, (key, oldVal) => newSchema);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private string Parse(string schemaData, string schemaName)
     {
         try
         {

--- a/src/Memphis.Client/Validators/ISchemaValidator.cs
+++ b/src/Memphis.Client/Validators/ISchemaValidator.cs
@@ -4,7 +4,7 @@ internal interface ISchemaValidator
 {
     Task ValidateAsync(byte[] messageToValidate, string schemaAsStr);
 
-    bool ParseAndStore(string schemeName, string schemaData);
+    bool AddOrUpdateSchema(SchemaUpdateInit schemaUpdate);
 
     void RemoveSchema(string schemaName);
 }

--- a/src/Memphis.Client/Validators/SchemaValidator.cs
+++ b/src/Memphis.Client/Validators/SchemaValidator.cs
@@ -6,32 +6,7 @@ internal abstract class SchemaValidator<TSchema>
 
     public SchemaValidator()
     {
-        this._schemaCache = new ConcurrentDictionary<string, TSchema>();
-    }
-
-    public bool ParseAndStore(string schemeName, string schemaData)
-    {
-        if (string.IsNullOrEmpty(schemeName))
-        {
-            throw new ArgumentException($"Invalid value provided for {schemeName}");
-        }
-
-        if (string.IsNullOrEmpty(schemaData))
-        {
-            throw new ArgumentException($"Invalid value provided for {schemaData}");
-        }
-
-        try
-        {
-            var newSchema = Parse(schemaData, schemeName);
-            _schemaCache.AddOrUpdate(schemeName, newSchema, (key, oldVal) => newSchema);
-
-            return true;
-        }
-        catch (System.Exception)
-        {
-            return false;
-        }
+        _schemaCache = new ConcurrentDictionary<string, TSchema>();
     }
 
     public void RemoveSchema(string schemaName)
@@ -39,5 +14,16 @@ internal abstract class SchemaValidator<TSchema>
         _schemaCache.TryRemove(schemaName, out TSchema _);
     }
 
-    protected abstract TSchema Parse(string schemaData, string schemaName);
+    protected bool IsSchemaUpdateValid(SchemaUpdateInit schemaUpdate)
+    {
+        if (schemaUpdate is null ||
+            schemaUpdate is { ActiveVersion: null })
+            return false;
+
+        if (string.IsNullOrEmpty(schemaUpdate.ActiveVersion.Content) ||
+            string.IsNullOrEmpty(schemaUpdate.SchemaName))
+            return false;
+
+        return true;
+    }
 }

--- a/src/ProtoBufEval.Tests/ProtoBufValidatorTests.cs
+++ b/src/ProtoBufEval.Tests/ProtoBufValidatorTests.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using ProtoBuf;
 using System.Text;
 
@@ -24,17 +25,30 @@ public class Test
 
 
 [ProtoContract]
-public class InvalidTestModel
+file class ValidModel
 {
 
     [ProtoMember(1, Name = @"field1")]
-    [global::System.ComponentModel.DefaultValue("")]
     public string Field1 { get; set; } = "";
+
+    [ProtoMember(2, Name = @"field2")]
+    public string Field2 { get; set; } = "";
 
     [ProtoMember(3, Name = @"field3")]
     public int Field3 { get; set; }
-
 }
+
+
+[ProtoContract]
+public class InvalidModel
+{
+    [ProtoMember(1, Name = @"field1")]
+    public string Field1 { get; set; } = "";
+
+    [ProtoMember(2, Name = @"field2")]
+    public string Field2 { get; set; } = "";
+}
+
 
 public class ProtoBufValidatorTests
 {
@@ -92,6 +106,36 @@ public class ProtoBufValidatorTests
     }
 
 
+    [Fact]
+    public async Task GivenInvalidData_WhenValidate_ThenHasError()
+    {
+        var base64InvalidData = ConvertProtoBufToBase64(new InvalidModel
+        {
+            Field1 = "AwesomeFirst",
+            Field2 = "SecondField"
+        });
+        var activeSchemaVersionBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(ActiveVersion()));
+
+        var result = await ProtoBufValidator.Validate(base64InvalidData, activeSchemaVersionBase64, "testschema");
+
+        Assert.True(result.HasError);
+    }
+
+    [Fact]
+    public async Task GivenValidData_WhenValidate_ThenHasError()
+    {
+        var base64InvalidData = ConvertProtoBufToBase64(new ValidModel
+        {
+            Field1 = "AwesomeFirst",
+            Field2 = "SecondField",
+            Field3 = 333,
+        });
+        var activeSchemaVersionBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(ActiveVersion()));
+
+        var result = await ProtoBufValidator.Validate(base64InvalidData, activeSchemaVersionBase64, "testschema");
+
+        Assert.False(result.HasError);
+    }
 
     private static string ConvertProtoBufToBase64<TData>(TData obj) where TData : class
     {
@@ -99,4 +143,16 @@ public class ProtoBufValidatorTests
         ProtoBuf.Serializer.Serialize(stream, obj);
         return Convert.ToBase64String(stream.ToArray());
     }
+
+    private static string ActiveVersion()
+    {
+        return JsonConvert.SerializeObject(new
+        {
+            version_number = 1,
+            descriptor = "CmQKEnRlc3RzY2hlbWFfMS5wcm90byJOCgRUZXN0EhYKBmZpZWxkMRgBIAIoCVIGZmllbGQxEhYKBmZpZWxkMhgCIAIoCVIGZmllbGQyEhYKBmZpZWxkMxgDIAIoBVIGZmllbGQz",
+            schema_content = "syntax = \"proto2\";\nmessage Test {\n            required string field1 = 1;\n            required string field2 = 2;\n            required int32 field3 = 3;\n}",
+            message_struct_name = "Test"
+        });
+    }
+
 }

--- a/src/ProtoBufEval/ProtoBufEvalMissingDependencyException.cs
+++ b/src/ProtoBufEval/ProtoBufEvalMissingDependencyException.cs
@@ -1,0 +1,8 @@
+namespace ProtoBufEval;
+
+internal class ProtoBufEvalMissingDependencyException : Exception
+{
+    public ProtoBufEvalMissingDependencyException(string message) : base(message)
+    {
+    }
+}

--- a/src/ProtoBufEval/RuntimeEnvironment.cs
+++ b/src/ProtoBufEval/RuntimeEnvironment.cs
@@ -1,5 +1,4 @@
 using System.IO.Compression;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace ProtoBufEval;
@@ -42,6 +41,7 @@ internal class RuntimeEnvironment
             var compressedBinary = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
                 ? Path.Combine(NativeBinariesDir, $"{OS}.zip")
                 : Path.Combine(NativeBinariesDir, $"{OS}-{Arch}.zip");
+            EnsureDependencyExists(compressedBinary);
             var binaryFilePath = Path.Combine(binaryDir, BinaryName);
             if (File.Exists(binaryFilePath))
                 File.Delete(binaryFilePath);
@@ -94,5 +94,11 @@ internal class RuntimeEnvironment
                 _ => throw new Exception("Unsupported OS architecture")
             };
         }
+    }
+
+    private static void EnsureDependencyExists(string path)
+    {
+        if (!File.Exists(path))
+            throw new ProtoBufEvalMissingDependencyException($"Missing dependency for ProtoBufEval: {path}");
     }
 }


### PR DESCRIPTION
**Fixes:**
 - Schema update listener checks if connection is open before throwing timeout exception
 - Consumer raises message event only if message count is > 0

**Update**
- Added `ToValidator` method on `MemphisSchemaTypes` to resolve corresponding validator type
- Added new unit tests on schema validators
- Added `AddOrUpdate` on schema validators

**Refactor**
- Removed redundant `SchemaTypes` class
- Removed generic `ParseAndStore`, and `Parse` methods from `SchemaValidator<T>`
- Moved consumer related methods in `MemphisClient` to partial class
- Updated schema update handler in `MemphisClient` to use `AddOrUpdate` of validators